### PR TITLE
Changed TaskDAO to flush JPA state on create so the database would

### DIFF
--- a/src/main/java/fi/otavanopisto/kuntaapi/server/controllers/TaskController.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/controllers/TaskController.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.persistence.PersistenceException;
 
 import org.hibernate.JDBCException;
 
@@ -74,21 +75,37 @@ public class TaskController {
   private Task createTask(String queueName, Boolean priority, TaskQueue taskQueue, byte[] data, String uniqueId) {
     try {
       return taskDAO.create(taskQueue, uniqueId, priority, data, OffsetDateTime.now());
+    } catch (PersistenceException e) {
+      handleCreateTaskErrorPersistence(queueName, uniqueId, e);
     } catch (JDBCException e) {
-      if (e.getCause() instanceof SQLException) {
-        SQLException sqlException = (SQLException) e.getCause();
-        if (sqlException.getErrorCode() == 1062) {
-          logger.warning(() -> String.format("Task %s insterted twice into queue %s. Skipped", uniqueId, queueName));
-          return null;
-        }
-      }
-      
-      logger.log(Level.SEVERE, "Could not create task", e);
+      handleCreateTaskErrorJdbc(queueName, uniqueId, e);
+    } catch (Exception e) {
+      logger.log(Level.SEVERE, "Task creating failed on unexpected error", e);
     }
     
     return null;
   }
   
+  private void handleCreateTaskErrorPersistence(String queueName, String uniqueId, PersistenceException e) {
+    if (e.getCause() instanceof JDBCException) {
+      handleCreateTaskErrorJdbc(queueName, uniqueId, (JDBCException) e.getCause());
+    } else {
+      logger.log(Level.SEVERE, "Task creating failed on unexpected persistence error", e);
+    }
+  }
+
+  private void handleCreateTaskErrorJdbc(String queueName, String uniqueId, JDBCException e) {
+    if (e.getCause() instanceof SQLException) {
+      SQLException sqlException = (SQLException) e.getCause();
+      if (sqlException.getErrorCode() == 1062) {
+        logger.warning(() -> String.format("Task %s insterted twice into queue %s. Skipped", uniqueId, queueName));
+        return;
+      }
+    }
+    
+    logger.log(Level.SEVERE, "Task creating failed on unexpected JDBC error", e);
+  }
+
   /**
    * Returns next tasks in queue
    * 

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/controllers/TaskController.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/controllers/TaskController.java
@@ -46,9 +46,9 @@ public class TaskController {
   public <T extends AbstractTask> Task createTask(String queueName, Boolean priority, T task) {
     TaskQueue taskQueue = taskQueueDAO.findByName(queueName);
     if (taskQueue == null) {
-      taskQueue = taskQueueDAO.create(queueName, "UNKNOWN");
+      taskQueue = createTaskQueue(queueName);
     }
-
+    
     byte[] data = serialize(task);
     if (data != null) {
       String uniqueId = task.getUniqueId();
@@ -139,6 +139,25 @@ public class TaskController {
    */
   public Long countTaskQueues() {
     return taskQueueDAO.count();
+  }
+  
+  /**
+   * Creates new task queue
+   * 
+   * @param name queue name
+   * @return created queue
+   */
+  public TaskQueue createTaskQueue(String name) {
+    return taskQueueDAO.create(name, "UNKNOWN");
+  }
+  
+  /**
+   * Returns task queue by name.
+   * 
+   * @return task queue
+   */
+  public TaskQueue findTaskQueueByName(String name) {
+    return taskQueueDAO.findByName(name);
   }
   
   /**

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/gtfs/GtfsIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/gtfs/GtfsIdUpdater.java
@@ -81,7 +81,7 @@ public class GtfsIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationGtfsTaskQueue.next();
     if (task != null) {
       updateGtfsEntities(task.getOrganizationId());
-    } else if (organizationGtfsTaskQueue.isEmpty()) {
+    } else if (organizationGtfsTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationGtfsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(GtfsConsts.ORGANIZATION_SETTING_GTFS_PATH));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/kuntarekry/KuntaRekryJobIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/kuntarekry/KuntaRekryJobIdUpdater.java
@@ -65,7 +65,7 @@ public class KuntaRekryJobIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationJobsTaskQueue.next();
     if (task != null) {
       updateOrganizationJobs(task.getOrganizationId());
-    } else if (organizationJobsTaskQueue.isEmpty()) {
+    } else if (organizationJobsTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationJobsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(KuntaRekryConsts.ORGANIZATION_SETTING_APIURI));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/linkedevents/updaters/LinkedEventsEventIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/linkedevents/updaters/LinkedEventsEventIdUpdater.java
@@ -73,7 +73,7 @@ public class LinkedEventsEventIdUpdater extends IdUpdater {
     if (task != null) {
       checkRemovedLinkedEventsEvent(task.getOrganizationId(), task.getOffset());
       updateLinkedEventsEvents(task.getOrganizationId(), task.getOffset());
-    } else if (organizationLinkedEventsEventTaskQueue.isEmpty()) {
+    } else if (organizationLinkedEventsEventTaskQueue.isEmptyAndLocalNodeResponsible()) {
       List<OrganizationId> kuntaApiOrganizationIds = organizationSettingController.listOrganizationIdsWithSetting(LinkedEventsConsts.ORGANIZATION_SETTING_BASEURL);
       for (OrganizationId kuntaApiOrganizationId : kuntaApiOrganizationIds) {
         long eventCount = getEventCount(kuntaApiOrganizationId);

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementAnnouncementIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementAnnouncementIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementAnnouncementIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationAnnouncementsTaskQueue.next();
     if (task != null) {
       updateManagementAnnouncements(task.getOrganizationId());
-    } else if (organizationAnnouncementsTaskQueue.isEmpty()) {
+    } else if (organizationAnnouncementsTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationAnnouncementsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementBannerIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementBannerIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementBannerIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationBannersTaskQueue.next();
     if (task != null) {
       updateManagementBanners(task.getOrganizationId());
-    } else if (organizationBannersTaskQueue.isEmpty()) {
+    } else if (organizationBannersTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationBannersTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementFragmentIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementFragmentIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementFragmentIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationFragmentsTaskQueue.next();
     if (task != null) {
       updateManagementFragments(task.getOrganizationId());
-    } else if (organizationFragmentsTaskQueue.isEmpty()) {
+    } else if (organizationFragmentsTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationFragmentsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementIncidentIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementIncidentIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementIncidentIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationIncidentsTaskQueue.next();
     if (task != null) {
       updateManagementIncidents(task.getOrganizationId());
-    } else if (organizationIncidentsTaskQueue.isEmpty()) {
+    } else if (organizationIncidentsTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationIncidentsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementMenuIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementMenuIdUpdater.java
@@ -64,7 +64,7 @@ public class ManagementMenuIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationMenusTaskQueue.next();
     if (task != null) {
       updateManagementMenus(task.getOrganizationId());
-    } else if (organizationMenusTaskQueue.isEmpty()) {
+    } else if (organizationMenusTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationMenusTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementNewsArticleIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementNewsArticleIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementNewsArticleIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationNewsArticlesTaskQueue.next();
     if (task != null) {
       updateManagementPosts(task.getOrganizationId());
-    } else if (organizationNewsArticlesTaskQueue.isEmpty()) {
+    } else if (organizationNewsArticlesTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationNewsArticlesTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementPageIdMapEntityUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementPageIdMapEntityUpdater.java
@@ -70,7 +70,7 @@ public class ManagementPageIdMapEntityUpdater extends EntityUpdater {
       OrganizationEntityUpdateTask task = organizationPageMapsTaskQueue.next();
       if (task != null) {
         updatePageIdMap(task.getOrganizationId());
-      } else if (organizationPageMapsTaskQueue.isEmpty()) {
+      } else if (organizationPageMapsTaskQueue.isEmptyAndLocalNodeResponsible()) {
         organizationPageMapsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
       }
     }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementPageIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementPageIdUpdater.java
@@ -61,7 +61,7 @@ public class ManagementPageIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationPagesTaskQueue.next();
     if (task != null) {
       updateManagementPages(task.getOrganizationId());
-    } else if (organizationPagesTaskQueue.isEmpty()) {
+    } else if (organizationPagesTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationPagesTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementRemovedPageIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementRemovedPageIdUpdater.java
@@ -59,7 +59,7 @@ public class ManagementRemovedPageIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationPageRemovesTaskQueue.next();
     if (task != null) {
       checkRemovedManagementPages(task.getOrganizationId(), task.getOffset());
-    } else if (organizationPageRemovesTaskQueue.isEmpty()) {
+    } else if (organizationPageRemovesTaskQueue.isEmptyAndLocalNodeResponsible()) {
       List<OrganizationId> kuntaApiOrganizationIds = organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL);
       for (OrganizationId kuntaApiOrganizationId : kuntaApiOrganizationIds) {
         Long pageCount = identifierController.countOrganizationPageIdsBySource(kuntaApiOrganizationId, ManagementConsts.IDENTIFIER_NAME);

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementShortlinkIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementShortlinkIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementShortlinkIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationShortlinksTaskQueue.next();
     if (task != null) {
       updateManagementShortlinks(task.getOrganizationId());
-    } else if (organizationShortlinksTaskQueue.isEmpty()) {
+    } else if (organizationShortlinksTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationShortlinksTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementTileIdUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/management/ManagementTileIdUpdater.java
@@ -68,7 +68,7 @@ public class ManagementTileIdUpdater extends IdUpdater {
     OrganizationEntityUpdateTask task = organizationTilesTaskQueue.next();
     if (task != null) {
       updateManagementTiles(task.getOrganizationId());
-    } else if (organizationTilesTaskQueue.isEmpty()) {
+    } else if (organizationTilesTaskQueue.isEmptyAndLocalNodeResponsible()) {
       organizationTilesTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(ManagementConsts.ORGANIZATION_SETTING_BASEURL));
     }
   }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/mikkelinyt/MikkeliNytEntityUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/mikkelinyt/MikkeliNytEntityUpdater.java
@@ -107,7 +107,7 @@ public class MikkeliNytEntityUpdater extends EntityUpdater {
       OrganizationEntityUpdateTask task = organizationEventsTaskQueue.next();
       if (task != null) {
         updateEvents(task.getOrganizationId());
-      } else if (organizationEventsTaskQueue.isEmpty()) {
+      } else if (organizationEventsTaskQueue.isEmptyAndLocalNodeResponsible()) {
         organizationEventsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(MikkeliNytConsts.ORGANIZATION_SETTING_BASEURL));
       }
     }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/vcard/VCardEntityUpdater.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/integrations/vcard/VCardEntityUpdater.java
@@ -99,7 +99,7 @@ public class VCardEntityUpdater extends EntityUpdater {
       if (task != null) {
         updateContacts(task.getOrganizationId());
       } else {
-        if (organizationVCardsTaskQueue.isEmpty()) {
+        if (organizationVCardsTaskQueue.isEmptyAndLocalNodeResponsible()) {
           organizationVCardsTaskQueue.enqueueTasks(organizationSettingController.listOrganizationIdsWithSetting(VCardConsts.ORGANIZATION_VCARD_FILE));
         }
       }

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/persistence/dao/TaskDAO.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/persistence/dao/TaskDAO.java
@@ -38,7 +38,9 @@ public class TaskDAO extends AbstractDAO<Task> {
     task.setData(data);
     task.setPriority(priority);
     task.setQueue(queue);
-    return persist(task);
+    Task result = persist(task);
+    flush();
+    return result;
   }
   
   /**

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/tasks/AbstractTaskQueue.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/tasks/AbstractTaskQueue.java
@@ -87,12 +87,12 @@ public abstract class AbstractTaskQueue <T extends AbstractTask> {
   }
 
   /**
-   * Returns whether current queue is empty
+   * Returns true if current queue is empty and local node is responsible from the queue
    * 
-   * @return true if current queue is empty, false otherwise
+   * @return true if current queue is empty and local node is responsible from the queue
    */
-  public boolean isEmpty() {
-    return taskController.isQueueEmpty(getName());
+  public boolean isEmptyAndLocalNodeResponsible() {
+    return taskController.isQueueEmpty(getName()) && taskController.isNodeResponsibleFromQueue(getName(), clusterController.getLocalNodeName());
   }
   
   /**

--- a/src/main/java/fi/otavanopisto/kuntaapi/server/tasks/AbstractTaskQueue.java
+++ b/src/main/java/fi/otavanopisto/kuntaapi/server/tasks/AbstractTaskQueue.java
@@ -35,6 +35,10 @@ public abstract class AbstractTaskQueue <T extends AbstractTask> {
   
   @PostConstruct
   public void postConstruct() {
+    if (taskController.findTaskQueueByName(getName()) == null) {
+      taskController.createTaskQueue(getName());
+    }
+    
     running = true;
   }
 


### PR DESCRIPTION
Resolves #383 by changing tasks to be flushed into database immediately, checking that empty queues belong to local node and finally by handling database exception more gracefully